### PR TITLE
Add ssh-auth for SSH tunneling via agent

### DIFF
--- a/io.dbeaver.DBeaverCommunity.yml
+++ b/io.dbeaver.DBeaverCommunity.yml
@@ -9,6 +9,7 @@ finish-args:
   - "--share=ipc"
   - "--socket=x11"
   - "--socket=wayland"
+  - "--socket=ssh-auth"
   - "--share=network"
   - "--socket=pulseaudio"
   - "--device=dri"


### PR DESCRIPTION
Hey, first time PRing to a Flathub repo, let me know if I'm making any faux-pas - 

Currently SSH tunneling with agent authentication doesn't work, saying "failed to initialize SSH agent". Adding --socket=ssh-auth predictably fixes the issue. As such, here's a one-line PR.