### PR TITLE
Update to version 7.1.3

### DIFF
--- a/io.dbeaver.DBeaverCommunity.appdata.xml
+++ b/io.dbeaver.DBeaverCommunity.appdata.xml
@@ -39,8 +39,8 @@
                     <li>PostgreSQL: data type DDL was improved + comment edit support was added</li>
                     <li>Oracle: problem with connect as SYSDBA was fixed</li>
                     <li>Exasol: (thaks to @Sargul)</li>
-                    <li>  Database error type discovery was added (proper handle of "connection lost" errors)</li>
-                    <li>  Metadata read performance was improved</li>
+                    <li>-  Database error type discovery was added (proper handle of "connection lost" errors)</li>
+                    <li>-  Metadata read performance was improved</li>
                     <li>Googlee Spanner: official driver configuration was added (thanks to @olavloite)</li>
                     <li>Simple view mode was fixed (redundant database objects were hidden)</li>
                     <li>Proxy configuration UI was fixed</li>

--- a/io.dbeaver.DBeaverCommunity.appdata.xml
+++ b/io.dbeaver.DBeaverCommunity.appdata.xml
@@ -30,6 +30,27 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="7.1.3" date="2020-07-19">
+            <description>
+                <ul style-type="none">
+                    <li>Spatial presentation: tooltips rendering was fixed</li>
+                    <li>DB2: UI tools were converted into database tasks</li>
+                    <li>MySQL/MariaDB: database restore was fixed (binary data corruption)</li>
+                    <li>PostgreSQL: data type DDL was improved + comment edit support was added</li>
+                    <li>Oracle: problem with connect as SYSDBA was fixed</li>
+                    <li>Exasol: (thaks to @Sargul)</li>
+                    <li>  Database error type discovery was added (proper handle of "connection lost" errors)</li>
+                    <li>  Metadata read performance was improved</li>
+                    <li>Googlee Spanner: official driver configuration was added (thanks to @olavloite)</li>
+                    <li>Simple view mode was fixed (redundant database objects were hidden)</li>
+                    <li>Proxy configuration UI was fixed</li>
+                    <li>MacOS installer was fixed (potential vulnerability was removed, thanks to @De4dCr0w)</li>
+                    <li>Tasks management: error handing was improved (for deleted tables)</li>
+                    <li>We reverted to Eeclipse 2020-03 platform (it resolves a set of UI glitches on some platforms)</li>
+                    <li>A few minor UI and database-specific bugs were fixed</li>
+                </ul>
+            </description>
+        </release>
         <release version="7.1.2" date="2020-07-05">
             <description>
                 <p>Data viewer:</p>
@@ -242,37 +263,6 @@
                     <li> SQLite: foreign key metadata read was fixed (FKs with no name)</li>
                     <li> Portuguese (BR) localization was added (thanks to @wellesximenes)</li>
                     <li> Many minor bug fixes and improvements</li>
-                </ul>
-            </description>
-        </release>
-        <release version="7.0.3" date="2020-04-19">
-            <description>
-                <ul>
-                    <li>Data viewer:</li>
-                    <li>Problem with unreachable last row/column was fixed</li>
-                    <li>"Open With" action now uses configuration from last data export</li>
-                    <li>Find/replace issues were fixed (scroll to found cell)</li>
-                    <li>Bug in reference panel was fixed (multiple value selection)</li>
-                    <li>Filter value auto-completion was fixed (popup close)</li>
-                    <li>Virtual unique keys management was improved</li>
-                    <li>SQL editor: multiline code templates apply was fixed (thanks to @VASilaev)</li>
-                    <li>Number of bugs were fixed in the Simple navigator view</li>
-                    <li>Transaction management was improved (redundant transaction commit confirmations were removed)</li>
-                    <li>GIS viewer: many new (and cool) tiles were added (thanks to @mkgrgis)</li>
-                    <li>Active catalog/schema selector UI was improved</li>
-                    <li>Connection edit dialog was fixed (error during page switch)</li>
-                    <li>Oracle:</li>
-                    <li>Connection settings (SID/Service) save was fixed</li>
-                    <li>Session terminate was fixed (for non-RAC databases)</li>
-                    <li>Exasol:</li>
-                    <li>Foreign key creation was fixed</li>
-                    <li>View DDL extraction was fixed (auto-format was disabled)</li>
-                    <li>HANA: unique key creation was fixed</li>
-                    <li>Firebird: procedure metadata refresh was fixed</li>
-                    <li>Problems with remote RDP connections (app crash) were fixed</li>
-                    <li>Japanese localization was significantly improved (thanks to @ScratchBuild)</li>
-                    <li>We have migrated to Eclipse platform 2020-03</li>
-                    <li>Many other minor bug fixes and improvements</li>
                 </ul>
             </description>
         </release>

--- a/io.dbeaver.DBeaverCommunity.appdata.xml
+++ b/io.dbeaver.DBeaverCommunity.appdata.xml
@@ -30,27 +30,7 @@
         </screenshot>
     </screenshots>
     <releases>
-        <release version="7.1.3" date="2020-07-19">
-            <description>
-                <ul style-type="none">
-                    <li>Spatial presentation: tooltips rendering was fixed</li>
-                    <li>DB2: UI tools were converted into database tasks</li>
-                    <li>MySQL/MariaDB: database restore was fixed (binary data corruption)</li>
-                    <li>PostgreSQL: data type DDL was improved + comment edit support was added</li>
-                    <li>Oracle: problem with connect as SYSDBA was fixed</li>
-                    <li>Exasol: (thaks to @Sargul)</li>
-                    <li>-  Database error type discovery was added (proper handle of "connection lost" errors)</li>
-                    <li>-  Metadata read performance was improved</li>
-                    <li>Googlee Spanner: official driver configuration was added (thanks to @olavloite)</li>
-                    <li>Simple view mode was fixed (redundant database objects were hidden)</li>
-                    <li>Proxy configuration UI was fixed</li>
-                    <li>MacOS installer was fixed (potential vulnerability was removed, thanks to @De4dCr0w)</li>
-                    <li>Tasks management: error handing was improved (for deleted tables)</li>
-                    <li>We reverted to Eeclipse 2020-03 platform (it resolves a set of UI glitches on some platforms)</li>
-                    <li>A few minor UI and database-specific bugs were fixed</li>
-                </ul>
-            </description>
-        </release>
+        <release version="7.1.3" date="2020-07-19" url="https://github.com/dbeaver/dbeaver/releases/tag/7.1.3" />
         <release version="7.1.2" date="2020-07-05">
             <description>
                 <p>Data viewer:</p>

--- a/io.dbeaver.DBeaverCommunity.yml
+++ b/io.dbeaver.DBeaverCommunity.yml
@@ -82,5 +82,5 @@ modules:
         dest-filename: dbeaver.tar.gz
         only-arches:
           - x86_64
-        url: https://github.com/dbeaver/dbeaver/releases/download/7.1.2/dbeaver-ce-7.1.2-linux.gtk.x86_64.tar.gz
-        sha256: 7861cd77e12e7fb79196c711261cdc8d886f026a7662e1301bfb0a458b473b8c
+        url: https://github.com/dbeaver/dbeaver/releases/download/7.1.3/dbeaver-ce-7.1.3-linux.gtk.x86_64.tar.gz
+        sha256: 0b91f0f56b30c4dc6c46f4a311de0b85b41ccccec99fe1d9e89c87a061060e45


### PR DESCRIPTION
The description uses `ul`/`li` tags instead of `p` for now.