### PR TITLE
Include XDG-Utils

### DIFF
--- a/io.dbeaver.DBeaverCommunity.yml
+++ b/io.dbeaver.DBeaverCommunity.yml
@@ -31,6 +31,14 @@ modules:
     buildsystem: simple
     build-commands:
       - /usr/lib/sdk/openjdk17/install.sh
+      
+  # Required by Eclips
+  - name: xdg-utils
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://portland.freedesktop.org/download/xdg-utils-1.1.3.tar.gz
+        sha256: d798b08af8a8e2063ddde6c9fa3398ca81484f27dec642c5627ffcaa0d4051d9      
 
   - name: dbeaver-client
     buildsystem: simple


### PR DESCRIPTION
Required by Eclipse or you'll get an error in org.eclipse.urischeme.internal.registration.RegistrationLinux.getRegisteredDesktopFileForScheme()