### PR TITLE
Add paragraph about installing OpenJDK extension first

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 Free multi-platform database tool for developers, SQL programmers, database administrators and analysts. Supports all popular databases: MySQL, PostgreSQL, MariaDB, SQLite, Oracle, DB2, SQL Server, Sybase, MS Access, Teradata, Firebird, Derby, etc.
 
 ## Flatpak local build test
+
+Make sure you install the OpenJDK SDK extension first, else the system will complain that it can't find
+the extension with the version of the GNOME SDK:
+
+```sh
+flatpak install org.freedesktop.Sdk.Extension.openjdk/x86_64/23.08
 ```
+
+To build and install the app execute:
+
+```sh
 flatpak-builder --repo=repo --force-clean build-dir io.dbeaver.DBeaverCommunity.yml
 ```

--- a/io.dbeaver.DBeaverCommunity.yml
+++ b/io.dbeaver.DBeaverCommunity.yml
@@ -45,7 +45,7 @@ modules:
       no-debuginfo: true
     buildsystem: simple
     build-commands:
-      - tar -xf dbeaver.tar.gz  --one-top-level=dbeaver_unpack
+      - tar -xf dbeaver.tar.gz --one-top-level=dbeaver_unpack
       - rm -rf dbeaver.tar.gz
       - cp -r dbeaver_unpack/dbeaver /app
       - install -d /app/clients/bin


### PR DESCRIPTION
It just cost me half an hour to figure out, why I couldn't build the app, I always got:
```
error: Requested extension org.freedesktop.Sdk.Extension.openjdk17/x86_64/45 not installed
```

There is no `45` branch available for the SDK extension, so I had to install the `23.08` branch manually and then it suddenly worked. Maybe it will save some time for someone else in the future.