### PR TITLE
Run on OpenJDK 21

### DIFF
--- a/io.dbeaver.DBeaverCommunity.yml
+++ b/io.dbeaver.DBeaverCommunity.yml
@@ -5,7 +5,7 @@ runtime-version: '45'
 
 sdk: org.gnome.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk17
+  - org.freedesktop.Sdk.Extension.openjdk21
 
 command: /app/dbeaver/dbeaver
 
@@ -38,7 +38,7 @@ modules:
       no-debuginfo: true
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk17/install.sh
+      - /usr/lib/sdk/openjdk21/install.sh
 
   - name: dbeaver-client
     build-options:


### PR DESCRIPTION
Since https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21 was created yesterday and on the DBeaver website it says
> DBeaver requires Java 17 or higher.

we can make use of it. Runs great so far, didn't encounter any issues.

Logs:
```
$ flatpak run io.dbeaver.DBeaverCommunity 
WARNING: Using incubator modules: jdk.incubator.vector
Warning: NLS unused message: WorkbenchPreference_showMultipleEditorTabsButton in: org.eclipse.ui.internal.messages
Warning: NLS unused message: ThemeChangeWarningHyperlinkedText in: org.eclipse.ui.internal.messages
Warning: NLS unused message: Workbench_zoomChangedRestart in: org.eclipse.ui.internal.messages
> Start Equinox Java Authentication and Authorization Service (JAAS) [org.eclipse.equinox.security 1.4.100.v20231012-1825]
> Start DBeaver Application Standalone [org.jkiss.dbeaver.ui.app.standalone 23.3.1.202312241705]
> Start Eclipse IDE UI-Anwendung [org.eclipse.ui.ide.application 1.5.200.v20231030-2045]
> Start Eclipse IDE UI [org.eclipse.ui.ide 3.22.0.v20231102-1012]
> Start DBeaver UI Editors - Base [org.jkiss.dbeaver.ui.editors.base 1.0.121.202312241705]
> Start Expression Language [org.eclipse.core.expressions 3.9.200.v20230921-0857]
> Start DBeaver Usage Statistics [org.jkiss.dbeaver.ui.statistics 1.0.17.202312241705]
> Start DBeaver Desktop Application Core [org.jkiss.dbeaver.core 23.3.1.202312241705]
> Start DBeaver UI [org.jkiss.dbeaver.ui 5.1.136.202312241705]
2024-01-03 11:30:59.388 - DBeaver 23.3.1.202312241705 is starting
2024-01-03 11:30:59.391 - OS: Linux 6.6.8-200.fc39.x86_64 (amd64)
2024-01-03 11:30:59.391 - Java version: 21.0.1 by Flathub (64bit)
2024-01-03 11:30:59.394 - Install path: '/app/dbeaver'
2024-01-03 11:30:59.394 - Instance path: 'file:/home/user/.local/share/DBeaverData/workspace6/'
2024-01-03 11:30:59.400 - Memory available 133Mb/1024Mb
2024-01-03 11:30:59.408 - Create display
2024-01-03 11:30:59.595 - Initialize desktop platform...
2024-01-03 11:30:59.955 - BounceCastle bundle found. Use JCE provider BC
...
```