### PR TITLE
Fix: Force DBeaver to use XDG DATA dirs instead of freely using the home directory

### DIFF
--- a/dbeaver.sh
+++ b/dbeaver.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec /app/bin/dbeaver -data "$XDG_DATA_HOME/workspace"

--- a/io.dbeaver.DBeaverCommunity.yml
+++ b/io.dbeaver.DBeaverCommunity.yml
@@ -22,7 +22,7 @@ finish-args:
   - --talk-name=org.freedesktop.FileManager1
   - --talk-name=org.freedesktop.secrets
   - --env=PATH=/app/clients/bin:/app/jre/bin:/usr/bin:/app/bin
-  - --persist=.swt
+  - --persist=.eclipse
 
 add-extensions:
   io.dbeaver.DBeaverCommunity.Client:

--- a/io.dbeaver.DBeaverCommunity.yml
+++ b/io.dbeaver.DBeaverCommunity.yml
@@ -20,6 +20,7 @@ finish-args:
   - --device=dri
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.FileManager1
+  - --talk-name=org.freedesktop.secrets
   - --env=PATH=/app/clients/bin:/app/jre/bin:/usr/bin:/app/bin
   - --persist=.swt
 

--- a/io.dbeaver.DBeaverCommunity.yml
+++ b/io.dbeaver.DBeaverCommunity.yml
@@ -8,7 +8,7 @@ sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
 
-command: dbeaver
+command: dbeaver.sh
 
 finish-args:
   - --share=ipc
@@ -20,8 +20,8 @@ finish-args:
   - --device=dri
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.FileManager1
-  - --filesystem=home
   - --env=PATH=/app/clients/bin:/app/jre/bin:/usr/bin:/app/bin
+  - --persist=.swt
 
 add-extensions:
   io.dbeaver.DBeaverCommunity.Client:
@@ -50,6 +50,7 @@ modules:
       - rm -rf dbeaver.tar.gz
       - cp -r ./dbeaver /app/bin
       - install -d /app/clients/bin
+      - install -Dm755 dbeaver.sh /app/bin/dbeaver.sh
       - install -Dm644 ./dbeaver/dbeaver-ce.desktop /app/share/applications/io.dbeaver.DBeaverCommunity.desktop
       - desktop-file-edit --remove-key=WMCLASS /app/share/applications/io.dbeaver.DBeaverCommunity.desktop
       - desktop-file-edit --remove-key=Categories /app/share/applications/io.dbeaver.DBeaverCommunity.desktop
@@ -63,7 +64,7 @@ modules:
       - desktop-file-edit --set-key=MimeType --set-value='application/sql;' /app/share/applications/io.dbeaver.DBeaverCommunity.desktop
       - desktop-file-edit --remove-key=Path /app/share/applications/io.dbeaver.DBeaverCommunity.desktop
       - desktop-file-edit --remove-key=Exec /app/share/applications/io.dbeaver.DBeaverCommunity.desktop
-      - desktop-file-edit --set-key=Exec --set-value='/app/bin/dbeaver' /app/share/applications/io.dbeaver.DBeaverCommunity.desktop
+      - desktop-file-edit --set-key=Exec --set-value='/app/bin/dbeaver.sh' /app/share/applications/io.dbeaver.DBeaverCommunity.desktop
       - desktop-file-edit --set-icon=io.dbeaver.DBeaverCommunity /app/share/applications/io.dbeaver.DBeaverCommunity.desktop
       - desktop-file-edit --set-key=Name --set-value='DBeaver CE' /app/share/applications/io.dbeaver.DBeaverCommunity.desktop
       - install -Dm644 io.dbeaver.DBeaverCommunity.appdata.xml /app/share/metainfo/io.dbeaver.DBeaverCommunity.appdata.xml
@@ -94,6 +95,8 @@ modules:
         sha256: f8ab6c3cf98cc239a050334313c06eed78b7e5703427bc22410e66dc211ddb43
       - type: file
         path: io.dbeaver.DBeaverCommunity.appdata.xml
+      - type: file
+        path: dbeaver.sh
       - type: file
         dest-filename: dbeaver.tar.gz
         only-arches:


### PR DESCRIPTION
Hi!

I wanted to share my adjustements to the Flatpak manifest, in order to better sandbox DBeaver:

- [x] Force the data to be stored in XDG dirs (`~/.var/app/io.dbeaver.DBeaverCommunity/data`) (fixes [this](https://github.com/flathub/io.dbeaver.DBeaverCommunity/issues/39#issuecomment-739441241), and maybe [this too](https://github.com/flathub/io.dbeaver.DBeaverCommunity/issues/156))
- [x] Persistent `~/.eclipse` that contains some configs and cache
- [x] Integration with the Secrets Portal, for the Master Password Settings