### PR TITLE
Update GNOME runtime to 48

### DIFF
--- a/io.dbeaver.DBeaverCommunity.yml
+++ b/io.dbeaver.DBeaverCommunity.yml
@@ -1,6 +1,6 @@
 app-id: io.dbeaver.DBeaverCommunity
 runtime: org.gnome.Platform
-runtime-version: '47'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 
 # Make sure to match the OpenJDK version with the linux.tar.gz
@@ -20,6 +20,7 @@ finish-args:
   - --device=dri
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.FileManager1
+  - --talk-name=org.freedesktop.secrets
   - --filesystem=home
   - --env=PATH=/app/clients/bin:/app/jre/bin:/usr/bin:/app/bin
 


### PR DESCRIPTION
Also allow SSH Agents, which was missing