### PR TITLE
use --persist instead of --filesystem=home

### DIFF
--- a/io.dbeaver.DBeaverCommunity.yml
+++ b/io.dbeaver.DBeaverCommunity.yml
@@ -20,7 +20,8 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.FileManager1
   - --talk-name=org.freedesktop.secrets
-  - --filesystem=home
+  - --persist=.local/share/DBeaverData
+  - --persist=.eclipse
   - --env=PATH=/app/clients/bin:/app/jre/bin:/usr/bin:/app/bin
 
 add-extensions:


### PR DESCRIPTION
I think this can be a good way of getting DBeaver to store its data on .var/app without doing a ton of changes.

flatpak will redirect ~/.local and ~/.eclipse to .var/app/io.dbeaver.DBeaverCommunity/{.local,.eclipse}